### PR TITLE
Add SubvertADown support

### DIFF
--- a/fuse.js
+++ b/fuse.js
@@ -5,8 +5,9 @@
         showSettingsBtn: 'fuseShowSettings',
         settingPanel: {
             name: 'fuseSettingsPanel',
-            tabs:  'fuseSettingsPanel__tabs',
-            borischen: 'fuseSettingsPanel__tabs__borischen'
+            tabs: 'fuseSettingsPanel__tabs',
+            borisChen: 'fuseSettingsPanel__tabs__borisChen',
+            subvertADown: 'fuseSettingsPanel__tabs__subvertADown'
         },
         localStorage: 'fuseStorage'
     }
@@ -20,7 +21,7 @@
             span.remove();
         });
 
-        const players = getStoredData().data.borischen.parsed;
+        const players = getStoredData().data.borisChen.parsed;
 
         document.querySelectorAll('.player-column__bio .AnchorLink.link').forEach(playerNameEl => {
             const name = playerNameEl.innerText;
@@ -61,51 +62,40 @@
         let settingsPanel = createMainSettingsPanel();
         const savedData = getStoredData().data
 
-        const borisChenTab = createBorisChenTab(savedData.borischen)
+        const borisChenTab = createBorisChenTab(savedData.borisChen)
 
-        const toggleBorisChenTab =  makeButton('BorisChen', () => {
-            hideAllTabs()            
-            showTab(borisChenTab.id)
+        const toggleBorisChenTab = makeButton('BorisChen', () => {
+            toggleTabs(borisChenTab.id)
         });
 
-        function hideAllTabs(){
-            const tabs = document.querySelectorAll(`.${selectors.settingPanel.tabs}`);
-
-            tabs.forEach(tab => {
-                tab.style.visibility = 'hidden';
-            });
-        };
-
-        function showTab(tabId){
-            var element = document.getElementById(tabId);    
-            element.style.visibility = 'visible';
-        }
-
+        const subvertADownTab = createSubvertADownTab(savedData.subvertADown);
+        const toggleSubvertADownTab = makeButton('SubvertADown', () => {
+            toggleTabs(subvertADownTab.id)
+        });
         settingsPanel.appendChild(toggleBorisChenTab);
-
+        settingsPanel.appendChild(toggleSubvertADownTab);
         settingsPanel.appendChild(borisChenTab);
-        settingsPanel.appendChild(document.createElement('br'));    
+        settingsPanel.appendChild(subvertADownTab);
+
+        settingsPanel.appendChild(document.createElement('br'));
 
         const saveBtn = makeButton('Save', () => {
-            let state = {
-                data: {
-                    borischen: {
-                        raw: getBorischenFormData(),
-                        parsed: {}
-                    }
-                }
-            }
+            let state = getStoredData();
 
-            state.data.borischen.parsed = parseBorischenRawData(state.data.borischen.raw);
+            state.data.borisChen.raw = getBorischenFormData();
+            state.data.borisChen.parsed = parseBorischenRawData(state.data.borisChen.raw);
+            state.data.subvertADown.raw = getSubvertADownFormData();
+            //state.data.subvertADown.parsed = parseSubvertADownRawData(state.data.borisChen.raw);
             saveToLocalStorage(state);
             hideSettings();
             updatePlayerInfo();
         });
-        
+
         settingsPanel.appendChild(saveBtn);
         settingsPanel.appendChild(makeButton('Hide', hideSettings));
 
         document.body.insertBefore(settingsPanel, document.getElementById(selectors.showSettingsBtn).nextSibling);
+        toggleTabs(borisChenTab.id);
 
         function createMainSettingsPanel() {
             const settingsPanel = document.createElement('div');
@@ -125,40 +115,94 @@
             return settingsPanel
         }
 
-        function createBorisChenTab(savedData){
+        function createBorisChenTab(savedData) {
             const tab = document.createElement('div');
-            tab.id = selectors.settingPanel.borischen;
+            tab.id = selectors.settingPanel.borisChen;
             tab.className = selectors.settingPanel.tabs;
             tab.appendChild(document.createElement('br'));
             const helpText = document.createElement('p');
 
-            helpText.textContent = 'To get the tier data from www.borischen.co for your league\'s point values and paste the raw tier info into the below text areas.';
+            helpText.textContent = 'To get the tier data from www.borisChen.co for your league\'s point values and paste the raw tier info into the below text areas.';
             tab.appendChild(helpText);
             tab.appendChild(document.createElement('br'));
-    
-            const positions = ['QB', 'RB', 'WR', 'TE', 'DST', 'K'];            
-    
+
+            const positions = ['QB', 'RB', 'WR', 'TE', 'DST', 'K'];
+
             for (const position of positions) {
                 const label = document.createElement('label');
-    
+
                 label.textContent = position;
-    
+
                 const textarea = document.createElement('textarea');
                 textarea.style.width = '350px';
-    
-                textarea.setAttribute('id', `${selectors.settingPanel.borischen}_${position}`);
+
+                textarea.setAttribute('id', `${selectors.settingPanel.borisChen}_${position}`);
                 if (savedData.raw[position]) {
                     textarea.value = savedData.raw[position];
                 }
-    
+
                 tab.appendChild(label);
                 tab.appendChild(document.createElement('br'));
-    
+
                 tab.appendChild(textarea);
-                tab.appendChild(document.createElement('br'));    
+                tab.appendChild(document.createElement('br'));
             }
 
             return tab;
+        }
+
+        function createSubvertADownTab(savedData) {
+            const tab = document.createElement('div');
+            tab.id = selectors.settingPanel.subvertADown;
+            tab.className = selectors.settingPanel.tabs;
+            tab.appendChild(document.createElement('br'));
+            const helpText = document.createElement('p');
+
+            helpText.textContent = 'Copy data from https://subvertadown.com and paste the raw tier info into the below text areas.';
+            tab.appendChild(helpText);
+            tab.appendChild(document.createElement('br'));
+
+            const positions = ['DST', 'QB', 'K'];
+
+            for (const position of positions) {
+                const label = document.createElement('label');
+
+                label.textContent = position;
+
+                const textarea = document.createElement('textarea');
+                textarea.style.width = '350px';
+
+                textarea.setAttribute('id', `${selectors.settingPanel.subvertADown}_${position}`);
+                if (savedData?.raw[position]) {
+                    textarea.value = savedData.raw[position];
+                }
+
+                tab.appendChild(label);
+                tab.appendChild(document.createElement('br'));
+
+                tab.appendChild(textarea);
+                tab.appendChild(document.createElement('br'));
+            }
+
+            return tab;
+        }
+
+        function hideAllTabs() {
+            const tabs = document.querySelectorAll(`.${selectors.settingPanel.tabs}`);
+
+            tabs.forEach(tab => {
+                tab.style.display = 'none';
+            });
+        };
+
+        function showTab(tabId) {
+            var element = document.getElementById(tabId);
+            element.style.display = 'block';
+        }
+
+        function toggleTabs(tabId) {
+            hideAllTabs();
+            showTab(tabId);
         }
     }
 
@@ -168,23 +212,54 @@
 
     function getStoredData() {
         const storedData = localStorage.getItem(selectors.localStorage);
-        const parsedData = JSON.parse(storedData) || {
+        const parsedData = JSON.parse(storedData) || {};
+
+        let defaults = {
             data: {
-                borischen: {
+                borisChen: {
+                    raw: {},
+                    parsed: {}
+                },
+                subvertADown: {
                     raw: {},
                     parsed: {}
                 }
             }
         };
 
-        console.log(parsedData)
+        const result = mergeDeep(defaults, parsedData)
 
-        return parsedData;
+        console.log(result)
+
+        return result;
     }
 
     function saveToLocalStorage(data) {
         localStorage.setItem(selectors.localStorage, JSON.stringify(data));
         console.log(data)
+    }
+
+    function isObject(item) {
+        return (item && typeof item === 'object' && !Array.isArray(item));
+    }
+
+
+    function mergeDeep(target, ...sources) {
+        if (!sources.length) return target;
+        const source = sources.shift();
+
+        if (isObject(target) && isObject(source)) {
+            for (const key in source) {
+                if (isObject(source[key])) {
+                    if (!target[key]) Object.assign(target, { [key]: {} });
+                    mergeDeep(target[key], source[key]);
+                } else {
+                    Object.assign(target, { [key]: source[key] });
+                }
+            }
+        }
+
+        return mergeDeep(target, ...sources);
     }
 
     function getBorischenFormData() {
@@ -193,7 +268,19 @@
         const positions = ['QB', 'RB', 'WR', 'TE', 'DST', 'K'];
 
         for (const position of positions) {
-            data[position] = document.getElementById(`${selectors.settingPanel.borischen}_${position}`).value;
+            data[position] = document.getElementById(`${selectors.settingPanel.borisChen}_${position}`).value;
+        }
+
+        return data;
+    }
+
+    function getSubvertADownFormData() {
+        const data = {};
+
+        const positions = ['QB', 'DST', 'K'];
+
+        for (const position of positions) {
+            data[position] = document.getElementById(`${selectors.settingPanel.subvertADown}_${position}`).value;
         }
 
         return data;
@@ -290,7 +377,7 @@
 
     function makeButton(text, onClick) {
         const button = document.createElement('button');
-        
+
         button.innerHTML = text;
         button.addEventListener('click', onClick);
 

--- a/fuse.js
+++ b/fuse.js
@@ -10,9 +10,7 @@
         localStorage: 'fuseStorage'
     }
 
-    const runUpdateBtn = makeButton(selectors.runUpdateBtn, 'Update', 150);
-
-    runUpdateBtn.addEventListener('click', updatePlayerInfo);
+    makePageButton(selectors.runUpdateBtn, 'Update', 150, updatePlayerInfo);
 
     function updatePlayerInfo() {
         const spans = document.querySelectorAll(`.${selectors.playerInfo}`);
@@ -50,9 +48,7 @@
         });
     }
 
-    const configure = makeButton(selectors.showSettingsBtn, '⚙', 175);
-
-    configure.addEventListener('click', editSettings);
+    makePageButton(selectors.showSettingsBtn, '⚙', 175, editSettings);
 
     function editSettings() {
         if (document.getElementById(selectors.settingPanel.name)) {
@@ -61,52 +57,13 @@
             return;
         }
 
-        const section = document.createElement('div');
+        let settingsPanel = createMainSettingsPanel();
+        const savedData = getStoredData().data
 
-        section.setAttribute('id', selectors.settingPanel.name);
-        section.style.position = 'absolute';
-        section.style.top = '200px';
-        section.style.right = '0';
-        section.style.backgroundColor = '#f9f9f9';
-        section.style.width = '200px';
+        const borisChenTab = createBorisChenTab(savedData.borischen)
+        settingsPanel.appendChild(borisChenTab);
 
-        section.style.padding = '15px';
-        section.style.border = '1px solid #ccc';
-        section.style.boxShadow = '0px 0px 10px rgba(0,0,0,0.1)';
-
-
-        const helpText = document.createElement('p');
-
-        helpText.textContent = 'To get the tier data from www.borischen.co for your league\'s point values and paste the raw tier info into the below text areas.';
-        section.appendChild(helpText);
-
-        const positions = ['QB', 'RB', 'WR', 'TE', 'DST', 'K'];
-        const savedData = getStoredData().data.borischen.raw;
-
-        for (const position of positions) {
-            const label = document.createElement('label');
-
-            label.textContent = position;
-
-            const textarea = document.createElement('textarea');
-
-            textarea.setAttribute('id', `${selectors.settingPanel.borischen}_${position}`);
-            if (savedData[position]) {
-                textarea.value = savedData[position];
-            }
-
-            section.appendChild(label);
-            section.appendChild(document.createElement('br'));
-
-            section.appendChild(textarea);
-            section.appendChild(document.createElement('br'));
-
-        }
-
-        const saveBtn = document.createElement('button');
-
-        saveBtn.textContent = 'Save';
-        saveBtn.addEventListener('click', () => {
+        const saveBtn = makeButton('Save', () => {
             let state = {
                 data: {
                     borischen: {
@@ -121,15 +78,60 @@
             hideSettings();
             updatePlayerInfo();
         });
-        section.appendChild(saveBtn);
+        
+        settingsPanel.appendChild(saveBtn);
+        settingsPanel.appendChild(makeButton('Hide', hideSettings));
 
-        const hideBtn = document.createElement('button');
+        document.body.insertBefore(settingsPanel, document.getElementById(selectors.showSettingsBtn).nextSibling);
 
-        hideBtn.textContent = 'Hide';
-        hideBtn.addEventListener('click', hideSettings);
-        section.appendChild(hideBtn);
+        function createMainSettingsPanel() {
+            const settingsPanel = document.createElement('div');
 
-        document.body.insertBefore(section, document.getElementById(selectors.showSettingsBtn).nextSibling);
+            settingsPanel.setAttribute('id', selectors.settingPanel.name);
+            settingsPanel.style.position = 'absolute';
+            settingsPanel.style.top = '200px';
+            settingsPanel.style.right = '0';
+            settingsPanel.style.backgroundColor = '#f9f9f9';
+            settingsPanel.style.width = '400px';
+
+            settingsPanel.style.padding = '15px';
+            settingsPanel.style.border = '1px solid #ccc';
+            settingsPanel.style.boxShadow = '0px 0px 10px rgba(0,0,0,0.1)';
+
+            return settingsPanel
+        }
+
+        function createBorisChenTab(savedData){
+            const tab = document.createElement('div');
+            tab.id = selectors.settingPanel.borischen;
+            const helpText = document.createElement('p');
+
+            helpText.textContent = 'To get the tier data from www.borischen.co for your league\'s point values and paste the raw tier info into the below text areas.';
+            tab.appendChild(helpText);
+    
+            const positions = ['QB', 'RB', 'WR', 'TE', 'DST', 'K'];            
+    
+            for (const position of positions) {
+                const label = document.createElement('label');
+    
+                label.textContent = position;
+    
+                const textarea = document.createElement('textarea');
+    
+                textarea.setAttribute('id', `${selectors.settingPanel.borischen}_${position}`);
+                if (savedData.raw[position]) {
+                    textarea.value = savedData.raw[position];
+                }
+    
+                tab.appendChild(label);
+                tab.appendChild(document.createElement('br'));
+    
+                tab.appendChild(textarea);
+                tab.appendChild(document.createElement('br'));    
+            }
+
+            return tab;
+        }
     }
 
     function hideSettings() {
@@ -235,17 +237,16 @@
         }
     }
 
-    function makeButton(id, text, offset) {
+    function makePageButton(id, text, offset, onClick) {
         const existingBtn = document.getElementById(id);
 
         if (document.contains(existingBtn)) {
             existingBtn.remove();
         }
 
-        const button = document.createElement('button');
-
+        const button = makeButton(text, onClick);
         button.id = id;
-        button.innerHTML = text;
+
         button.style.position = 'absolute';
         button.style.top = `${offset}px`;
         button.style.right = 0;
@@ -255,6 +256,15 @@
         const body = document.getElementsByTagName('body')[0];
 
         body.appendChild(button);
+
+        return button;
+    }
+
+    function makeButton(text, onClick) {
+        const button = document.createElement('button');
+        
+        button.innerHTML = text;
+        button.addEventListener('click', onClick);
 
         return button;
     }

--- a/fuse.js
+++ b/fuse.js
@@ -284,13 +284,13 @@
         function parseSubvertADownFormRawData(rawData) {
             const players = {};
 
-            processData(rawData.DST, players);
+            processData(rawData.DST, players, true);
             processData(rawData.QB, players);
             processData(rawData.K, players);
 
             return players;
 
-            function processData(input, players) {
+            function processData(input, players, isDST) {
                 const lines = input.trim().split('\n');
 
                 let player = '';
@@ -302,6 +302,10 @@
 
                     if (!player) {
                         player = line.split('|')[0].trim();
+
+                        if(isDST){
+                            player = `${player} D/ST`;
+                        }
                     } else {
                         value = line.trim();
                         players[player] = value;

--- a/fuse.js
+++ b/fuse.js
@@ -21,13 +21,17 @@
             span.remove();
         });
 
-        const players = getStoredData().data.borisChen.parsed;
+        const data = getStoredData().data;
+        const borisChen = data.borisChen.parsed
+        const subvertADown = data.subvertADown.parsed
 
         document.querySelectorAll('.player-column__bio .AnchorLink.link').forEach(playerNameEl => {
             const name = playerNameEl.innerText;
-            const playerTier = players[name];
+            const borisChenTier = borisChen[name];
+            const subvertADownValue = subvertADown[name];
+            const info = [borisChenTier, subvertADownValue].filter(val => val);
 
-            if (!playerTier || !name) {
+            if (!info.length || !name) {
                 return
             }
 
@@ -42,7 +46,7 @@
                     span.className = selectors.playerInfo;
                     span.style.marginRight = '2px';
                     span.style.fontWeight = '900';
-                    span.textContent = playerTier;
+                    span.textContent = `${info.join('/')}`;
 
                     playerPositionElem.insertBefore(span, playerPositionElem.firstChild);
                 }
@@ -285,7 +289,7 @@
             processData(rawData.K, players);
 
             return players;
-            
+
             function processData(input, players) {
                 const lines = input.trim().split('\n');
 

--- a/fuse.js
+++ b/fuse.js
@@ -5,7 +5,8 @@
         showSettingsBtn: 'fuseShowSettings',
         settingPanel: {
             name: 'fuseSettingsPanel',
-            borischen: 'fuseSettingsPanel_borischen'
+            tabs:  'fuseSettingsPanel__tabs',
+            borischen: 'fuseSettingsPanel__tabs__borischen'
         },
         localStorage: 'fuseStorage'
     }
@@ -61,7 +62,29 @@
         const savedData = getStoredData().data
 
         const borisChenTab = createBorisChenTab(savedData.borischen)
+
+        const toggleBorisChenTab =  makeButton('BorisChen', () => {
+            hideAllTabs()            
+            showTab(borisChenTab.id)
+        });
+
+        function hideAllTabs(){
+            const tabs = document.querySelectorAll(`.${selectors.settingPanel.tabs}`);
+
+            tabs.forEach(tab => {
+                tab.style.visibility = 'hidden';
+            });
+        };
+
+        function showTab(tabId){
+            var element = document.getElementById(tabId);    
+            element.style.visibility = 'visible';
+        }
+
+        settingsPanel.appendChild(toggleBorisChenTab);
+
         settingsPanel.appendChild(borisChenTab);
+        settingsPanel.appendChild(document.createElement('br'));    
 
         const saveBtn = makeButton('Save', () => {
             let state = {
@@ -93,6 +116,7 @@
             settingsPanel.style.right = '0';
             settingsPanel.style.backgroundColor = '#f9f9f9';
             settingsPanel.style.width = '400px';
+            settingsPanel.style.padding = '10px';
 
             settingsPanel.style.padding = '15px';
             settingsPanel.style.border = '1px solid #ccc';
@@ -104,10 +128,13 @@
         function createBorisChenTab(savedData){
             const tab = document.createElement('div');
             tab.id = selectors.settingPanel.borischen;
+            tab.className = selectors.settingPanel.tabs;
+            tab.appendChild(document.createElement('br'));
             const helpText = document.createElement('p');
 
             helpText.textContent = 'To get the tier data from www.borischen.co for your league\'s point values and paste the raw tier info into the below text areas.';
             tab.appendChild(helpText);
+            tab.appendChild(document.createElement('br'));
     
             const positions = ['QB', 'RB', 'WR', 'TE', 'DST', 'K'];            
     
@@ -117,6 +144,7 @@
                 label.textContent = position;
     
                 const textarea = document.createElement('textarea');
+                textarea.style.width = '350px';
     
                 textarea.setAttribute('id', `${selectors.settingPanel.borischen}_${position}`);
                 if (savedData.raw[position]) {


### PR DESCRIPTION
Updated FUSE to support multiple data sources, specifically SubvertADown for the DST and Kicker streaming suggestions (but also pulled in the QB info as well).

Updates include
- Buttons to show/hide BorisChen and SubvertADown tabs
- SubvertADown with DST, Kicker, and QB inputs
- Parsing of SubvertADown data (copy/pasta from [home page](https://subvertadown.com/)
- Displaying both BorisChen and SubvertADown info

![image](https://github.com/jarekb84/FUSE/assets/667983/e724210f-cb8e-48d8-9b6b-6a8e999cf0d2)

Players with both sets of data
![image](https://github.com/jarekb84/FUSE/assets/667983/94d5d412-3e43-45dd-9216-49f1ecf43d8e)
![image](https://github.com/jarekb84/FUSE/assets/667983/71d706ee-a500-451f-bc6e-77ed1ff33255)

Players with just BorisChen info
![image](https://github.com/jarekb84/FUSE/assets/667983/86b76453-ae27-40c4-bc42-a0c535da8490)

Player with just SubvertADown data
![image](https://github.com/jarekb84/FUSE/assets/667983/b47c28ee-c623-4a91-b4d3-292f1d29a64c)

