### PR TITLE
7 run player info update on initial load

### DIFF
--- a/fuse.js
+++ b/fuse.js
@@ -24,14 +24,21 @@
         });
 
         const data = getStoredData().data;
-        const borisChen = data.borisChen.parsed
-        const subvertADown = data.subvertADown.parsed
+        const borisChen = data.borisChen;
+        const subvertADown = data.subvertADown;
 
         document.querySelectorAll('.player-column__bio .AnchorLink.link').forEach(playerNameEl => {
             const name = playerNameEl.innerText;
-            const borisChenTier = borisChen[name];
-            const subvertADownValue = subvertADown[name];
-            const info = [borisChenTier, subvertADownValue].filter(val => val);
+            const borisChenTier = borisChen.parsed[name];
+            const subvertADownValue = subvertADown.parsed[name];
+            let info = [];
+
+            if(borisChenTier){
+                info.push(`${borisChen.prefix || ''}${borisChenTier}`)
+            }
+            if(subvertADownValue){
+                info.push(`${subvertADown.prefix || ''}${subvertADownValue}`)
+            }
 
             if (!info.length || !name) {
                 return
@@ -88,9 +95,9 @@
         const saveBtn = makeButton('Save', () => {
             let state = getStoredData();
 
-            state.data.borisChen.raw = getBorischenFormData();
+            state.data.borisChen = {...state.data.borisChen, ...getBorischenFormData()};
             state.data.borisChen.parsed = parseBorischenRawData(state.data.borisChen.raw);
-            state.data.subvertADown.raw = getSubvertADownFormData();
+            state.data.subvertADown = {...state.data.borisChen, ...getSubvertADownFormData()};
             state.data.subvertADown.parsed = parseSubvertADownFormRawData(state.data.subvertADown.raw);
             saveToLocalStorage(state);
             hideSettings();
@@ -132,6 +139,20 @@
             tab.appendChild(helpText);
             tab.appendChild(document.createElement('br'));
 
+            const prefixLabel = document.createElement('label');
+            prefixLabel.textContent = 'Prefix (optional)';
+
+            const prefixInput = document.createElement('input');
+            prefixInput.id = `${selectors.settingPanel.borisChen}_prefix`
+            prefixInput.placeholder = 'Ex: BC'
+            prefixInput.value = savedData.prefix;
+
+            tab.appendChild(prefixLabel);
+            tab.appendChild(document.createElement('br'));
+            tab.appendChild(prefixInput);
+
+            tab.appendChild(document.createElement('br'));
+
             const positions = ['QB', 'RB', 'WR', 'TE', 'DST', 'K'];
 
             for (const position of positions) {
@@ -158,12 +179,15 @@
         }
 
         function getBorischenFormData() {
-            const data = {};
+            const data = {
+                raw: {},
+                prefix: document.getElementById(`${selectors.settingPanel.borisChen}_prefix`).value
+            };
 
             const positions = ['QB', 'RB', 'WR', 'TE', 'DST', 'K'];
 
             for (const position of positions) {
-                data[position] = document.getElementById(`${selectors.settingPanel.borisChen}_${position}`).value;
+                data.raw[position] = document.getElementById(`${selectors.settingPanel.borisChen}_${position}`).value;
             }
 
             return data;
@@ -246,6 +270,20 @@
             tab.appendChild(helpText);
             tab.appendChild(document.createElement('br'));
 
+            const prefixLabel = document.createElement('label');
+            prefixLabel.textContent = 'Prefix (optional)';
+
+            const prefixInput = document.createElement('input');
+            prefixInput.id = `${selectors.settingPanel.subvertADown}_prefix`
+            prefixInput.placeholder = 'Ex: SD'
+            prefixInput.value = savedData.prefix;
+
+            tab.appendChild(prefixLabel);
+            tab.appendChild(document.createElement('br'));
+            tab.appendChild(prefixInput);
+
+            tab.appendChild(document.createElement('br'));
+
             const positions = ['DST', 'QB', 'K'];
 
             for (const position of positions) {
@@ -272,12 +310,15 @@
         }
 
         function getSubvertADownFormData() {
-            const data = {};
+            const data = {
+                raw: {},
+                prefix: document.getElementById(`${selectors.settingPanel.subvertADown}_prefix`).value
+            };
 
             const positions = ['QB', 'DST', 'K'];
 
             for (const position of positions) {
-                data[position] = document.getElementById(`${selectors.settingPanel.subvertADown}_${position}`).value;
+                data.raw[position] = document.getElementById(`${selectors.settingPanel.subvertADown}_${position}`).value;
             }
 
             return data;

--- a/fuse.js
+++ b/fuse.js
@@ -12,6 +12,8 @@
         localStorage: 'fuseStorage'
     }
 
+    updatePlayerInfo();
+
     makePageButton(selectors.runUpdateBtn, 'Update', 150, updatePlayerInfo);
 
     function updatePlayerInfo() {
@@ -395,7 +397,6 @@
 
         return mergeDeep(target, ...sources);
     }
-
 
     function makePageButton(id, text, offset, onClick) {
         const existingBtn = document.getElementById(id);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuse",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "FUSE: Fantasy User Stat Enhancer",
   "main": "fuse.js",  
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fuse",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "FUSE: Fantasy User Stat Enhancer",
   "main": "fuse.js",  
   "repository": {


### PR DESCRIPTION
Add prefixes to the data injected to player info to better distinguish between what's being shown from where 

![image](https://github.com/jarekb84/FUSE/assets/667983/98ce8367-5397-43b0-ae97-ba21e5bb09b8)

![image](https://github.com/jarekb84/FUSE/assets/667983/10c3c0f5-958e-4e36-96f7-5dda9d0204c1)

Note, no padding is added by default, up to users if they want to add a space or other delimiter 

Default (no prefixes)
![image](https://github.com/jarekb84/FUSE/assets/667983/c50577ca-e792-45a1-b426-82ec6aa91eb7)

Both use prefix
![image](https://github.com/jarekb84/FUSE/assets/667983/f263719b-3726-4853-a990-5677dce88780)


Example of mixed use of prefixes
![image](https://github.com/jarekb84/FUSE/assets/667983/aada2ce4-36e7-4f17-a1a1-6526112b0451)

