### PR TITLE
FIX save button being hidden below the page on small resolutions

### DIFF
--- a/fuse.js
+++ b/fuse.js
@@ -201,7 +201,7 @@
         }
     }
 
-    makePageButton(selectors.showSettingsBtn, '⚙', 175, editSettings);
+    makePageButton(selectors.showSettingsBtn, '⚙', 100, editSettings);
 
     function editSettings() {
         if (document.getElementById(selectors.settingPanel.name)) {
@@ -274,12 +274,12 @@
 
             settingsPanel.setAttribute('id', selectors.settingPanel.name);
             settingsPanel.style.position = 'fixed';
-            settingsPanel.style.top = '200px';
+            settingsPanel.style.top = '125px';
             settingsPanel.style.right = '0';
             settingsPanel.style.backgroundColor = '#f9f9f9';
-            settingsPanel.style.width = '400px';
+            settingsPanel.style.width = '410px';
             settingsPanel.style.padding = '10px';
-            settingsPanel.style.zIndex = '1000';
+            settingsPanel.style.zIndex = '9999999';
             settingsPanel.style.textAlign = 'left';
 
             settingsPanel.style.padding = '15px';
@@ -719,7 +719,7 @@
         button.style.top = `${offset}px`;
         button.style.right = 0;
         button.style.color = 'green';
-        button.style['z-index'] = '10000';
+        button.style.zIndex = '9999999';
         button.style.fontSize = '16px';
         button.style.padding = '1px 6px';
         button.style.marginRight = '0';
@@ -751,6 +751,8 @@
         tab.id = id;
         tab.className = selectors.settingPanel.tabs;
         tab.style.padding = '10px';
+        tab.style.maxHeight = '70vh';
+        tab.style.overflowY = 'auto';
 
         const helpText = document.createElement('p');
         helpText.textContent = content;


### PR DESCRIPTION
To address issue
- Moved main gear icon closer to the top of the page
- added a max height to the contents which align with view port size

![image](https://github.com/jarekb84/FUSE/assets/667983/ea24ed91-730b-4566-8a7a-95c52a7a90f7)

This isn't a perfect solutions since the buttons become hidden below 700px in height
![image](https://github.com/jarekb84/FUSE/assets/667983/edb24f9f-a714-4798-84bf-f697c4c84cff)


Could make the whole container have a max height, but then I get a permanent scrollbar due to the version placeholder which uses absolute positioning.

![image](https://github.com/jarekb84/FUSE/assets/667983/070ddab8-f48c-45c6-aac9-7144c8717412)
