### PR TITLE
76 violent monkey error settings wont load

### DIFF
--- a/fuse.user.js
+++ b/fuse.user.js
@@ -51,10 +51,10 @@
                 get: () => document.getElementById(`${idBase}`),
                 getValue: function () {
                     if (attribute === 'value'){
-                        return this.get() ? this.get()[attribute] : null;
+                        return this.get() ? this.get()[attribute] : '';
                     }
 
-                    return this.get() ? this.get().getAttribute(attribute) : null;
+                    return this.get() ? this.get().getAttribute(attribute) : '';
                 },
                 setValue: function (value) {
                     return this.get().setAttribute(attribute, value);
@@ -491,7 +491,7 @@
                         get: (position) => document.getElementById(`${SETTINGS.selectors.tabs.id}_borisChen_${position}`),
                         getValue: function (position) {
                             const el = this.get(position);
-                            return el ? el.value : null;
+                            return el ? el.value : '';
                         },
                         setValue: function (position, value) {
                             return this.get(position).value = value;
@@ -797,7 +797,7 @@
                         get: (position) => document.getElementById(`${SETTINGS.selectors.tabs.id}_subvertADown_${position}`),
                         getValue: function (position) {
                             const el = this.get(position);
-                            return el ? el.value : null;
+                            return el ? el.value : '';
                         }
                     }
                 }

--- a/fuse.user.js
+++ b/fuse.user.js
@@ -1270,7 +1270,7 @@
                 optionElement.value = option;
                 optionElement.textContent = option;
 
-                if (option.toString() === selectedValue.toString()) {
+                if (option.toString() === selectedValue?.toString()) {
                     optionElement.selected = true;
                 }
 


### PR DESCRIPTION
When GM info isn't found (ie loading via bookmarklet) the UI does not render the dropdowns for autoFetch and text for lastFetched. When you click Save in that scenario, the selector 'getValue' functions had a fallback of null if the element did not exist. This resulted in null being returned when `getFormData` was called during the save operation, resulting in `null` being saved for any property which wasn't displayed into local stroage.

So the next time you opened the settings panel, it would retrieve the prior saved settings state, see those nulls, and use them as the selectedValue parameter when creating dropdowns. Hence the bug and the screenshot.

 The two updates around this should reduce the possibility of this type of error coming up again.
- selector's getValue factory functions now have a default fallback of an empty string
- selectedValue check uses optional chaining operator to not blow up if I do miss this in the future