### PR TITLE
46 add settings tab

### DIFF
--- a/fuse.user.js
+++ b/fuse.user.js
@@ -349,7 +349,7 @@
                 selector: FUSE.selectors.tabs.id,
                 tabLabels: {
                     backgroundColor: '#eee',
-                    activeBackgroundColor: 'rgb(249, 249, 249',
+                    activeBackgroundColor: 'rgb(249, 249, 249)',
                     padding: '5px',
                     beforeContent: true,
                 },
@@ -460,7 +460,7 @@
                 selector: self.selectors.root.id,
                 tabLabels: {
                     backgroundColor: '#eee',
-                    activeBackgroundColor: 'rgb(249, 249, 249',
+                    activeBackgroundColor: 'rgb(249, 249, 249)',
                     beforeContent: true,
                     padding: '10px',
                 },
@@ -1341,7 +1341,7 @@
                 selector: self.selectors.root.id,
                 tabLabels: {
                     backgroundColor: '#eee',
-                    activeBackgroundColor: 'rgb(249, 249, 249',
+                    activeBackgroundColor: 'rgb(249, 249, 249)',
                     padding: '5px',
                     beforeContent: true,
                 },

--- a/fuse.user.js
+++ b/fuse.user.js
@@ -354,7 +354,8 @@
             hideSettings,
             selectors: {
                 panel: UI.makeSelector('fuseSettingsPanel'),
-                tabs: UI.makeSelector('fuseSettingsPanel__tabs'),
+                tabLabels: UI.makeSelector('fuseSettingsPanel__tabLabel'),
+                tabContents: UI.makeSelector('fuseSettingsPanel__tabContent'),
             }
         }
 
@@ -367,34 +368,37 @@
                 return;
             }
 
-            let settingsPanel = createMainSettingsPanel();
-            let contentContainer = document.createElement('div');
-            contentContainer.style.cssText = `
-                padding: 10px;
-            `;
-
             const state = STORE.getState().data
 
+            let settingsPanel = createMainSettingsPanel();
+            let contentContainer = document.createElement('div');            
+
             const borisChenTab = BORISCHEN.settingsPanel.createTab(state.borisChen)
-            const toggleBorisChenTab = DOM.makeButton('BorisChen', () => {
-                toggleTabs(borisChenTab.id)
-            });
-
             const subvertADownTab = SUBVERTADOWN.settingsPanel.createSubvertADownTab(state.subvertADown);
-            const toggleSubvertADownTab = DOM.makeButton('SubvertADown', () => {
-                toggleTabs(subvertADownTab.id)
-            });
-
             const customDataTab = CUSTOMDATA.settingsPanel.createCustomDataTab(state.customData);
-            const toggleCustomData = DOM.makeButton('CustomData', () => {
-                toggleTabs(customDataTab.id)
-            });
-            contentContainer.appendChild(toggleBorisChenTab);
-            contentContainer.appendChild(toggleSubvertADownTab);
-            contentContainer.appendChild(toggleCustomData);
+
+            contentContainer.appendChild(DOM.makeTabs([
+                { contentSelector: borisChenTab.id, label: 'BorisChen', default: true },
+                { contentSelector: subvertADownTab.id, label: 'SubvertADown' },
+                { contentSelector: customDataTab.id, label: 'CustomData' }
+            ], {
+                tabLabelsSelector: self.selectors.tabLabels.id,
+                tabContentsSelector: self.selectors.tabContents.id,
+                tabLabels: {
+                    backgroundColor: '#eee',
+                    activeBackgroundColor: 'rgb(249, 249, 249',
+                }
+            }));
+
             contentContainer.appendChild(borisChenTab);
             contentContainer.appendChild(subvertADownTab);
             contentContainer.appendChild(customDataTab);
+
+            let actionsSection = document.createElement('div');
+            actionsSection.style.cssText = `
+                padding: 10px;
+                border-top: 1px solid #ccc;
+            `;
 
             const saveBtn = DOM.makeButton('Save', () => {
                 let state = STORE.getState();
@@ -408,13 +412,14 @@
                 UI.injectFUSEInfoIntoFantasySite();
             });
 
-            contentContainer.appendChild(saveBtn);
-            contentContainer.appendChild(DOM.makeButton('Hide', hideSettings));
+            actionsSection.appendChild(saveBtn);
+            actionsSection.appendChild(DOM.makeButton('Hide', hideSettings));
             settingsPanel.appendChild(contentContainer);
+            settingsPanel.appendChild(actionsSection);
             settingsPanel.appendChild(createInfoSection());
 
             document.body.insertBefore(settingsPanel, document.getElementById(showSettingsBtn.id).nextSibling);
-            toggleTabs(borisChenTab.id);
+            activateTab(borisChenTab.id);
 
             function createInfoSection() {
                 const info = document.createElement('div');
@@ -451,23 +456,6 @@
                 return settingsPanel
             }
 
-            function hideAllTabs() {
-                const tabs = document.querySelectorAll(`.${self.selectors.tabs.id}`);
-
-                tabs.forEach(tab => {
-                    tab.style.display = 'none';
-                });
-            };
-
-            function showTab(tabId) {
-                var element = document.getElementById(tabId);
-                element.style.display = 'block';
-            }
-
-            function toggleTabs(tabId) {
-                hideAllTabs();
-                showTab(tabId);
-            }
         }
 
         function hideSettings() {
@@ -477,7 +465,7 @@
 
     function makeBorisChenModule() {
         function borisChenSelector(id, attribute) {
-            return UI.makeSelector(`${SETTINGS.selectors.tabs.id}__borisChen_${id}`, attribute);
+            return UI.makeSelector(`${SETTINGS.selectors.tabContents.id}__borisChen_${id}`, attribute);
         }
 
         const scoreSuffix = {
@@ -501,8 +489,8 @@
                     lastFetched: borisChenSelector('lastFetched', 'data-state'),
                     fetchDataBtn: borisChenSelector('fetchDataBtn'),
                     positions: {
-                        id: (position) => `${SETTINGS.selectors.tabs.id}_borisChen_${position}`,
-                        get: (position) => document.getElementById(`${SETTINGS.selectors.tabs.id}_borisChen_${position}`),
+                        id: (position) => `${SETTINGS.selectors.tabContents.id}_borisChen_${position}`,
+                        get: (position) => document.getElementById(`${SETTINGS.selectors.tabContents.id}_borisChen_${position}`),
                         getValue: function (position) {
                             const el = this.get(position);
                             return el ? el.value : '';
@@ -688,7 +676,10 @@
             const { selectors } = self.settingsPanel;
             const tab = DOM.makeTabElement(
                 selectors.tab.id,
-                "To get the tier data from www.borisChen.co for your league's point values and paste the raw tier info into the below text areas."
+                "Configure your league scoring setting and automatically fetch data from from www.borisChen.co or paste it in manually.",
+                {
+                    active: true
+                }
             );
 
             const prefixField = DOM.makeInputField(
@@ -795,7 +786,7 @@
 
     function makeSubvertADownModule() {
         function subvertADownSelector(id, attribute) {
-            return UI.makeSelector(`${SETTINGS.selectors.tabs.id}__subvertADown_${id}`, attribute);
+            return UI.makeSelector(`${SETTINGS.selectors.tabContents.id}__subvertADown_${id}`, attribute);
         }
 
         const self = {
@@ -809,8 +800,8 @@
                     prefix: subvertADownSelector('prefix'),
                     raw: subvertADownSelector('raw'),
                     positions: {
-                        id: (position) => `${SETTINGS.selectors.tabs.id}_subvertADown_${position}`,
-                        get: (position) => document.getElementById(`${SETTINGS.selectors.tabs.id}_subvertADown_${position}`),
+                        id: (position) => `${SETTINGS.selectors.tabContents.id}_subvertADown_${position}`,
+                        get: (position) => document.getElementById(`${SETTINGS.selectors.tabContents.id}_subvertADown_${position}`),
                         getValue: function (position) {
                             const el = this.get(position);
                             return el ? el.value : '';
@@ -933,7 +924,7 @@
 
     function makeCustomDataModule() {
         function customDataSelector(id, attribute) {
-            return UI.makeSelector(`${SETTINGS.selectors.tabs.id}__customData_${id}`, attribute);
+            return UI.makeSelector(`${SETTINGS.selectors.tabContents.id}__customData_${id}`, attribute);
         }
 
         const self = {
@@ -1145,8 +1136,7 @@
     }
 
     function makeDOMModule() {
-
-        return {
+        const self = {
             makePageButton,
             makeButton,
             makeTabElement,
@@ -1154,8 +1144,11 @@
             makeReadOnlyField,
             makeInputField,
             makeTextAreaField,
-            makeDropdownField
+            makeDropdownField,
+            makeTabs
         }
+
+        return self;
 
         function makePageButton(id, text, offset, onClick) {
             const existingBtn = document.getElementById(id);
@@ -1202,14 +1195,15 @@
             return button;
         }
 
-        function makeTabElement(id, content) {
+        function makeTabElement(id, content, options) {
             const tab = document.createElement('div');
             tab.id = id;
-            tab.className = SETTINGS.selectors.tabs.id;
+            tab.className = SETTINGS.selectors.tabContents.id;
             tab.style.cssText += `
                 padding: 10px;
                 max-height: 70vh;
                 overflow-y: auto;
+                display: ${options?.active ? 'block' : 'none'};
             `;
 
             const helpText = document.createElement('p');
@@ -1313,6 +1307,69 @@
             field.appendChild(selectElement);
 
             return field;
+        }
+
+        function makeTabs(tabs, options) {
+            const tabsContainer = document.createElement('div');
+            tabsContainer.style.cssText = `
+                display: flex;  
+                justify-content: space-between;
+                background-color: ${options.tabLabels.backgroundColor};  
+            `;
+
+            tabs.forEach(tab => {
+                const tabNameLabel = document.createElement('div');
+                tabNameLabel.textContent = tab.label;
+                tabNameLabel.id = `${tab.contentSelector}_label`;
+                tabNameLabel.classList.add(options.tabLabelsSelector);
+
+                tabNameLabel.style.cssText = `
+                    padding: 10px;
+                    width: 100%;
+                    cursor: pointer;
+                    border-bottom: 1px solid #ccc;
+                    background-color: inherit;
+                `;
+
+                if(tab.default){
+                    tabNameLabel.style.borderBottom = 'none';
+                    tabNameLabel.style.backgroundColor = options.tabLabels.activeBackgroundColor;
+                }
+
+                tabNameLabel.addEventListener('click', () => {
+                    hideAllTabs();
+                    showTab(tab.contentSelector);
+                });
+
+                tabsContainer.appendChild(tabNameLabel);
+            });
+
+            return tabsContainer;
+
+
+            function hideAllTabs() {
+                const tabLabel = document.querySelectorAll(`.${options.tabLabelsSelector}`);
+
+                tabLabel.forEach(tab => {
+                    tab.style.borderBottom = '1px solid #ccc';
+                    tab.style.backgroundColor = 'inherit';
+                });
+
+                const tabContents = document.querySelectorAll(`.${options.tabContentsSelector}`);
+
+                tabContents.forEach(tab => {
+                    tab.style.display = 'none';
+                });
+            };
+
+            function showTab(contentSelector) {
+                let tabNameLabel = document.getElementById(`${contentSelector}_label`);
+                tabNameLabel.style.borderBottom = 'none';
+                tabNameLabel.style.backgroundColor = options.tabLabels.activeBackgroundColor;
+
+                let tabContent = document.getElementById(`${contentSelector}`);
+                tabContent.style.display = 'block';
+            }
         }
     }
 }

--- a/fuse.user.js
+++ b/fuse.user.js
@@ -372,9 +372,9 @@
             let settingsPanel = createMainSettingsPanel();
             let contentContainer = document.createElement('div');
 
-            const borisChenTab = BORISCHEN.settingsPanel.createTab(state.borisChen)
-            const subvertADownTab = SUBVERTADOWN.settingsPanel.createSubvertADownTab(state.subvertADown);
-            const customDataTab = CUSTOMDATA.settingsPanel.createCustomDataTab(state.customData);
+            const borisChenTab = BORISCHEN.settingsPanel.createTabContent(state.borisChen)
+            const subvertADownTab = SUBVERTADOWN.settingsPanel.createTabContent(state.subvertADown);
+            const customDataTab = CUSTOMDATA.settingsPanel.createTabContent(state.customData);
 
             contentContainer.appendChild(DOM.makeTabs([
                 { label: 'BorisChen', default: true, contents: borisChenTab },
@@ -473,7 +473,7 @@
             updateState,
             getPlayerInfo,
             settingsPanel: {
-                createTab,
+                createTabContent,
                 selectors: {
                     tab: borisChenSelector('tab'),
                     prefix: borisChenSelector('prefix'),
@@ -665,7 +665,7 @@
             }
         }
 
-        function createTab(savedData) {
+        function createTabContent(savedData) {
             const { selectors } = self.settingsPanel;
             const tabContent = document.createElement('div');
             const helpText = document.createElement('p');
@@ -785,7 +785,7 @@
             updateState,
             getPlayerInfo,
             settingsPanel: {
-                createSubvertADownTab,
+                createTabContent,
                 selectors: {
                     tab: subvertADownSelector('tab'),
                     prefix: subvertADownSelector('prefix'),
@@ -829,7 +829,7 @@
 
             return `${state.prefix || ''}${playerInfo}`
         }
-        function createSubvertADownTab(savedData) {
+        function createTabContent(savedData) {
             const tabContent = document.createElement('div');
 
             const helpText = document.createElement('p');
@@ -925,7 +925,7 @@
             updateState,
             getPlayerInfo,
             settingsPanel: {
-                createCustomDataTab,
+                createTabContent,
                 selectors: {
                     tab: customDataSelector('tab'),
                     prefix: customDataSelector('prefix'),
@@ -968,7 +968,7 @@
             return `${state.prefix || ''}${playerInfo}`
         }
 
-        function createCustomDataTab(savedData) {
+        function createTabContent(savedData) {
             const { selectors } = self.settingsPanel;
             const tabContent = document.createElement('div');
 

--- a/fuse.user.js
+++ b/fuse.user.js
@@ -99,81 +99,47 @@
 
         function injectFUSEInfoIntoFantasySite() {
             const spans = document.querySelectorAll(`.${self.selectors.playerInfo}`);
-            const state = STORE.getState().data;
+            const state = STORE.getState();
+            const dataSources = state.data;
+            const settings = state.settings;
 
             spans.forEach(span => {
                 span.remove();
             });
 
             if (window.location.host === 'fantasy.espn.com') {
-                updateESPNPlayerInfo();
+                updatePlatformPlayerInfo('espn');
             }
 
             if (window.location.host === 'football.fantasysports.yahoo.com') {
-                updateYahooPlayerInfo();
+                updatePlatformPlayerInfo('yahoo');
             }
 
             if (window.location.host === 'fantasy.nfl.com') {
-                updateNFLPlayerInfo();
+                updatePlatformPlayerInfo('nfl');
             }
 
             if (window.location.host === 'sleeper.com') {
-                updateSleeperPlayerInfo();
+                updatePlatformPlayerInfo('sleeper');
             }
 
             if (window.location.host.includes('football.cbssports.com')) {
-                updateCBSPlayerInfo();
+                updatePlatformPlayerInfo('cbs');
             }
 
-            function updateESPNPlayerInfo() {
-                document.querySelectorAll('.player-column__bio .AnchorLink.link').forEach(playerNameEl => {
-                    insertFUSEPlayerInfo(playerNameEl, '.player-column__bio', '.player-column__position');
-                });
-            }
+            function updatePlatformPlayerInfo(platformName) {
+                let platform = SETTINGSTAB.platformSelectors[platformName]
 
-            function updateYahooPlayerInfo() {
-                document.querySelectorAll('.ysf-player-name a').forEach(playerNameEl => {
-                    insertFUSEPlayerInfo(playerNameEl, 'td', '.ysf-player-detail', { fontWeight: '700' });
-                });
-            }
+                for (const [pageName, page] of Object.entries(platform)) {
+                    let pageOverrides = settings.platformSelectors[platformName]?.[pageName];
+                    const playerName = pageOverrides?.playerName?.playerName_override || page.playerName;
+                    const parent = pageOverrides?.parent?.parent_override || page.parent;
+                    const rowAfterPlayerName = pageOverrides?.rowAfterPlayerName?.rowAfterPlayerName_override || page.rowAfterPlayerName;
 
-            function updateNFLPlayerInfo() {
-                document.querySelectorAll('.playerName').forEach(playerNameEl => {
-                    insertFUSEPlayerInfo(playerNameEl, '.playerNameAndInfo', 'em', { fontWeight: '900' });
-                });
-            }
-
-            function updateSleeperPlayerInfo() {
-                // matchup page
-                document.querySelectorAll('.matchup-player-item .player-name > div:first-child').forEach(playerNameEl => {
-                    insertFUSEPlayerInfo(playerNameEl, '.player-name', '.player-pos', { fontWeight: '900' });
-                });
-
-                // team page
-                document.querySelectorAll('.team-roster-item .player-name').forEach(playerNameEl => {
-                    insertFUSEPlayerInfo(playerNameEl, '.cell-player-meta', '.game-schedule-live-description', { fontWeight: '900' });
-                });
-
-                // players page
-                document.querySelectorAll('.player-meta-container .name').forEach(playerNameEl => {
-                    insertFUSEPlayerInfo(playerNameEl, '.name-container', '.position', { fontWeight: '900' });
-                });
-
-                // trend page
-                document.querySelectorAll('.trending-list-item .name').forEach(playerNameEl => {
-                    insertFUSEPlayerInfo(playerNameEl, '.player-details', '.position', { fontWeight: '900' });
-                });
-
-                // scores page
-                document.querySelectorAll('.scores-content .player-meta .name').forEach(playerNameEl => {
-                    insertFUSEPlayerInfo(playerNameEl, '.player-meta', '.position', { fontWeight: '900' });
-                });
-            }
-
-            function updateCBSPlayerInfo() {
-                document.querySelectorAll('.playerLink').forEach(playerNameEl => {
-                    insertFUSEPlayerInfo(playerNameEl, 'td', 'playerPositionAndTeam', { fontWeight: '900', marginLeft: '2px' });
-                });
+                    document.querySelectorAll(playerName).forEach(playerNameEl => {
+                        insertFUSEPlayerInfo(playerNameEl, parent, rowAfterPlayerName);
+                    });
+                }
             }
 
             function insertFUSEPlayerInfo(playerNameEl, parentSelector, rowAfterPlayerNameSelector, styles) {
@@ -202,9 +168,9 @@
                 const playerName = name.replace(' D/ST', '').trim();
 
                 let info = [
-                    BORISCHEN.getPlayerInfo(state.borisChen, playerName),
-                    SUBVERTADOWN.getPlayerInfo(state.subvertADown, playerName),
-                    CUSTOMDATA.getPlayerInfo(state.customData, playerName),
+                    BORISCHEN.getPlayerInfo(dataSources.borisChen, playerName),
+                    SUBVERTADOWN.getPlayerInfo(dataSources.subvertADown, playerName),
+                    CUSTOMDATA.getPlayerInfo(dataSources.customData, playerName),
                 ];
 
                 return info.filter(i => i).join('/');
@@ -1215,6 +1181,7 @@
             getDefaultState,
             updateState,
             makeSettingsTabContent,
+            platformSelectors,
             selectors: {
                 root: settingsTabSelector()
             }

--- a/fuse.user.js
+++ b/fuse.user.js
@@ -1161,63 +1161,63 @@
         return self;
 
         const platformSelectors = {
-            espn: [{
-                pageName: 'Common',
-                playerName: '.player-column__bio .AnchorLink.link',
-                parent: '.player-column__bio',
-                rowAfterPlayerName: '.player-column__position'
-            }],
-            yahoo: [{
-                pageName: 'Common',
-                playerName: '.ysf-player-name a',
-                parent: 'td',
-                rowAfterPlayerName: '.ysf-player-detail'
-            }],
-            nfl: [{
-                pageName: 'Common',
-                playerName: '.playerName',
-                parent: '.playerNameAndInfo',
-                rowAfterPlayerName: 'em',
-            }],
-            cbs: [{
-                pageName: 'Common',
-                playerName: '.playerLink',
-                parent: 'td',
-                rowAfterPlayerName: '.playerPositionAndTeam'
-            }],
-            sleeper: [
-                {
-                    pageName: 'Matchup',
+            espn: {
+                common: {            
+                    playerName: '.player-column__bio .AnchorLink.link',
+                    parent: '.player-column__bio',
+                    rowAfterPlayerName: '.player-column__position'
+                }
+            },
+            yahoo: {
+                common: {
+                    playerName: '.ysf-player-name a',
+                    parent: 'td',
+                    rowAfterPlayerName: '.ysf-player-detail'
+                }
+            },
+            nfl: {
+                common: {
+                    playerName: '.playerName',
+                    parent: '.playerNameAndInfo',
+                    rowAfterPlayerName: 'em',
+                }
+            },
+            cbs: {
+                common: {
+                    playerName: '.playerLink',
+                    parent: 'td',
+                    rowAfterPlayerName: '.playerPositionAndTeam'
+                }
+            },
+            sleeper: {
+                matchup: {
                     playerName: '.matchup-player-item .player-name > div:first-child',
                     parent: '.player-name',
                     rowAfterPlayerName: '.player-pos'
                 },
-                {
-                    pageName: 'Team',
+                team: {
                     playerName: '.team-roster-item .player-name',
                     parent: '.cell-player-meta',
                     rowAfterPlayerName: '.game-schedule-live-description'
                 },
-                {
-                    pageName: 'Players',
+                players: {
                     playerName: '.player-meta-container .name',
                     parent: '.name-container',
                     rowAfterPlayerName: '.position'
                 },
-                {
-                    pageName: 'Trend',
+                trend: {
                     playerName: '.trending-list-item .name',
                     parent: '.player-details',
                     rowAfterPlayerName: '.position'
                 },
-                {
-                    pageName: 'Scores',
+                scores: {
                     playerName: '.scores-content .player-meta .name',
                     parent: '.player-meta',
                     rowAfterPlayerName: '.position'
                 },
-            ]
+            }
         }
+        
         function getDefaultState() {
             return {
 

--- a/fuse.user.js
+++ b/fuse.user.js
@@ -26,6 +26,9 @@
     const BORISCHEN = makeBorisChenModule();
     const SUBVERTADOWN = makeSubvertADownModule();
     const CUSTOMDATA = makeCustomDataModule();
+
+    const SETTINGSTAB = makeSettingsTabModule();
+
     const PLAYERS = makePlayersModule();
 
     const DSTNames = PLAYERS.getDSTNames();
@@ -350,47 +353,6 @@
         }
     }
 
-    function makeDataSourcesTabModule() {
-        function dataSourcesTabSelector() {
-            return UI.makeSelector(`${FUSE.selectors.tabs.id}__dataSources`);
-        }
-        const self = {
-            makeDataSourcesTabContent,
-            selectors: {
-                root: dataSourcesTabSelector()
-            }
-        }
-
-        return self;
-
-        function makeDataSourcesTabContent() {
-            const state = STORE.getState().data
-            let tabContent = document.createElement('div');
-
-            const borisChenTab = BORISCHEN.dataSourcesTab.createTabContent(state.borisChen)
-            const subvertADownTab = SUBVERTADOWN.dataSourcesTab.createTabContent(state.subvertADown);
-            const customDataTab = CUSTOMDATA.dataSourcesTab.createTabContent(state.customData);
-
-            tabContent.appendChild(DOM.makeTabs([
-                { label: 'BorisChen', default: true, contents: borisChenTab },
-                { label: 'SubvertADown', contents: subvertADownTab },
-                { label: 'CustomData', contents: customDataTab }
-            ], {
-                selector: self.selectors.root.id,
-                tabLabels: {
-                    backgroundColor: '#eee',
-                    activeBackgroundColor: 'rgb(249, 249, 249',
-                    beforeContent: true,
-                    padding: '10px',
-                },
-                tabContent: {
-                    padding: '10px',
-                }
-            }));
-
-            return tabContent
-        }
-    }
     function makeFUSEConfiguratorModule() {
         const self = {
             openConfigurator,
@@ -412,8 +374,7 @@
 
             let configModal = createConfiguratorModal();
             const dataSourcesTab = DATASOURCESTAB.makeDataSourcesTabContent();
-            let settingsTab = document.createElement('div');
-            settingsTab.innerText = 'Settings content'
+            let settingsTab = SETTINGSTAB.makeSettingsTabContent();
             configModal.appendChild(DOM.makeTabs([
                 { label: 'Data', default: true, contents: dataSourcesTab },
                 { label: 'Settings', contents: settingsTab },
@@ -499,6 +460,49 @@
 
         function closeConfigurator() {
             document.body.removeChild(self.selectors.panel.get());
+        }
+    }
+
+    function makeDataSourcesTabModule() {
+        function dataSourcesTabSelector() {
+            return UI.makeSelector(`${FUSE.selectors.tabs.id}__dataSources`);
+        }
+        const self = {
+            makeDataSourcesTabContent,
+            selectors: {
+                root: dataSourcesTabSelector()
+            }
+        }
+
+        return self;
+
+        function makeDataSourcesTabContent() {
+            const state = STORE.getState().data
+            let tabContent = document.createElement('div');
+
+            const borisChenTab = BORISCHEN.dataSourcesTab.createTabContent(state.borisChen)
+            const subvertADownTab = SUBVERTADOWN.dataSourcesTab.createTabContent(state.subvertADown);
+            const customDataTab = CUSTOMDATA.dataSourcesTab.createTabContent(state.customData);
+
+            tabContent.appendChild(DOM.makeTabs([
+                { label: 'BorisChen', default: true, contents: borisChenTab },
+                { label: 'SubvertADown', contents: subvertADownTab },
+                { label: 'CustomData', contents: customDataTab }
+            ], {
+                selector: self.selectors.root.id,
+                tabLabels: {
+                    backgroundColor: '#eee',
+                    activeBackgroundColor: 'rgb(249, 249, 249',
+                    beforeContent: true,
+                    padding: '10px',
+                },
+                tabContent: {
+                    padding: '10px',
+                    level: 1
+                }
+            }));
+
+            return tabContent
         }
     }
 
@@ -724,8 +728,10 @@
             const prefixField = DOM.makeInputField(
                 'Prefix (optional)',
                 selectors.prefix.id,
-                'Ex: BC',
-                savedData.prefix,
+                savedData.prefix, 
+                {
+                    placeholder: 'Ex: BC'
+                }
             );
 
             tabContent.appendChild(prefixField);
@@ -889,8 +895,10 @@
             const prefixField = DOM.makeInputField(
                 'Prefix (optional)',
                 self.dataSourcesTab.selectors.prefix.id,
-                'Ex: SD',
                 savedData.prefix,
+                {
+                    placeholder: 'Ex: SD'
+                }
             );
 
             tabContent.appendChild(prefixField);
@@ -1030,8 +1038,10 @@
             const prefixField = DOM.makeInputField(
                 'Prefix (optional)',
                 selectors.prefix.id,
-                'Ex: C',
-                savedData.prefix,
+                savedData.prefix, 
+                {
+                    placeholder: 'Ex: C'
+                }
             );
 
             tabContent.appendChild(prefixField);
@@ -1127,6 +1137,232 @@
             }
 
             return playersDictionary;
+        }
+    }
+
+    function makeSettingsTabModule() {
+        const rootSelector = `${FUSE.selectors.tabs.id}__settings`;
+        function settingsTabSelector(id, attribute) {
+            return UI.makeSelector(`${rootSelector}_${id}`, attribute);
+        }
+
+        function platformSelectorsSelector(id, attribute){
+            return settingsTabSelector(`platformSelectors__${id}`, attribute)
+        }
+        const self = {
+            getDefaultState,
+            updateState, // TODO make
+            makeSettingsTabContent,
+            selectors: {
+                root: settingsTabSelector()
+            }
+        }
+
+        return self;
+
+        const platformSelectors = {
+            espn: [{
+                pageName: 'Common',
+                playerName: '.player-column__bio .AnchorLink.link',
+                parent: '.player-column__bio',
+                rowAfterPlayerName: '.player-column__position'
+            }],
+            yahoo: [{
+                pageName: 'Common',
+                playerName: '.ysf-player-name a',
+                parent: 'td',
+                rowAfterPlayerName: '.ysf-player-detail'
+            }],
+            nfl: [{
+                pageName: 'Common',
+                playerName: '.playerName',
+                parent: '.playerNameAndInfo',
+                rowAfterPlayerName: 'em',
+            }],
+            cbs: [{
+                pageName: 'Common',
+                playerName: '.playerLink',
+                parent: 'td',
+                rowAfterPlayerName: '.playerPositionAndTeam'
+            }],
+            sleeper: [
+                {
+                    pageName: 'Matchup',
+                    playerName: '.matchup-player-item .player-name > div:first-child',
+                    parent: '.player-name',
+                    rowAfterPlayerName: '.player-pos'
+                },
+                {
+                    pageName: 'Team',
+                    playerName: '.team-roster-item .player-name',
+                    parent: '.cell-player-meta',
+                    rowAfterPlayerName: '.game-schedule-live-description'
+                },
+                {
+                    pageName: 'Players',
+                    playerName: '.player-meta-container .name',
+                    parent: '.name-container',
+                    rowAfterPlayerName: '.position'
+                },
+                {
+                    pageName: 'Trend',
+                    playerName: '.trending-list-item .name',
+                    parent: '.player-details',
+                    rowAfterPlayerName: '.position'
+                },
+                {
+                    pageName: 'Scores',
+                    playerName: '.scores-content .player-meta .name',
+                    parent: '.player-meta',
+                    rowAfterPlayerName: '.position'
+                },
+            ]
+        }
+        function getDefaultState() {
+            return {
+
+            }
+        }
+
+        function updateState(oldState) {
+            let newState = {
+                ...oldState, ...getSettingsTabFormData()
+            }
+
+            return newState;
+        }
+
+        function getSettingsTabFormData(){
+            const data = {
+                general:{
+
+                },
+                platformSelectors: {
+                    
+                }
+            }
+
+            Object.keys(platformSelectors).forEach(platform => {
+                let platformHeading = document.createElement('h4');
+                platformHeading.textContent = platform;
+                platformSelectorsSubTab.appendChild(platformHeading);
+                platformSelectors[platform].forEach((selectorGroup, selectorGroupIndex) => {
+                    Object.keys(selectorGroup).forEach(key => {
+                            data.platformSelectors[platform][selectorGroupIndex] = {
+                                
+                            }
+
+                            platformSelectors[platform][selectorGroupIndex].selectors[key] = {
+                                keySelector,
+                                keyOverrideSelector
+                            };
+
+                    })
+
+                })
+
+            });
+        }
+
+        function makeSettingsTabContent() {
+            const tabContent = document.createElement('div');
+            tabContent.style.cssText = `
+                padding: 10px;
+            `
+            const platformSelectorsSubTab = document.createElement('div');
+
+            Object.keys(platformSelectors).forEach(platform => {
+                let platformHeading = document.createElement('h4');
+                platformHeading.textContent = platform;
+                platformSelectorsSubTab.appendChild(platformHeading);
+                platformSelectors[platform].forEach((selectorGroup, selectorGroupIndex) => {
+                    Object.keys(selectorGroup).forEach(key => {
+                        if (key === 'pageName' && selectorGroup.pageName) {
+                            let pageHeading = document.createElement('h5');
+                            pageHeading.textContent = `${selectorGroup.pageName} Page`;
+                            platformSelectorsSubTab.appendChild(pageHeading);
+                        } else {
+                            let keySelector = platformSelectorsSelector(`${platform}_${selectorGroup.pageName}_${key}`)
+                            let keyOverrideSelector = platformSelectorsSelector( `${keySelector.id}_override`);
+                            platformSelectorsSubTab.appendChild(
+                                DOM.makeInputField(
+                                    key, 
+                                    keySelector.id, 
+                                    selectorGroup[key], 
+                                    { disabled: true }
+                                )
+                            );
+                            let fieldInput = DOM.makeInputField(
+                                `${key} Override`,
+                                keyOverrideSelector.id,
+                                '', // todo set value from state
+                                { styles: 'width: 100%' }
+                            );
+                            if(!platformSelectors[platform][selectorGroupIndex].selectors){
+                                platformSelectors[platform][selectorGroupIndex].selectors = {}
+                            }
+
+                            platformSelectors[platform][selectorGroupIndex].selectors[key] = {
+                                keySelector,
+                                keyOverrideSelector
+                            };
+                            
+                            platformSelectorsSubTab.appendChild(fieldInput)
+                        }
+
+                    })
+
+                })
+
+            });
+
+            const generalTab = document.createElement('div');
+            let delimiterSectionHeading = document.createElement('h3');
+            delimiterSectionHeading.textContent = `Delimiters`;
+            generalTab.appendChild(delimiterSectionHeading);
+
+            let dataSourceDelimiterField = DOM.makeInputField(
+                'Between Data Sources',
+                'self.dataSourcesTab.selectors.prefix.iddfdsafasd',  // todo figure out selector
+
+                '/',
+                {
+                    styles: 'width: 100%',
+                    placeholder: 'Ex: /'
+                }
+            );
+
+            let samePlayerWithinDataSourcesField = DOM.makeInputField(
+                'Player listed multiple times in a given data set',
+                'self.dataSourcesTab.selectors.prefix.iddfdsafasd',  // todo figure out selector                
+                '|',
+                { styles: 'width: 100%', placeholder: 'Ex: |' }
+            );
+
+            generalTab.appendChild(dataSourceDelimiterField)
+            generalTab.appendChild(samePlayerWithinDataSourcesField)
+
+
+            tabContent.appendChild(DOM.makeTabs([
+                { label: 'General', default: true, contents: generalTab },
+                { label: 'Platform Selectors', contents: platformSelectorsSubTab },
+            ], {
+                selector: self.selectors.root.id,
+                tabLabels: {
+                    backgroundColor: '#eee',
+                    activeBackgroundColor: 'rgb(249, 249, 249',
+                    padding: '5px',
+                    beforeContent: true,
+                },
+                tabContent: {
+                    padding: '10px',
+                    level: 1
+                }
+            }));
+
+
+            return tabContent
+
         }
     }
 
@@ -1252,6 +1488,7 @@
             const field = document.createElement('div');
             const label = makeLabelElement(labelText);
             const displayValue = document.createElement('span');
+
             displayValue.id = id;
             displayValue.setAttribute('data-state', state);
             displayValue.style.marginBottom = '10px';
@@ -1263,19 +1500,21 @@
             return field;
         }
 
-        function makeInputField(labelText, id, placeholder, value,) {
+        function makeInputField(labelText, id, value, options = {}) {
             const field = document.createElement('div');
             const label = makeLabelElement(labelText)
 
             const input = document.createElement('input');
             input.id = id;
-            input.placeholder = placeholder;
+            input.placeholder = options.placeholder || '';
             input.value = value || '';
+            input.disabled = options.disabled;
             input.style.cssText = `
                 margin-bottom: 10px;
-                background-color: white;
+                ${options.disabled ? '' : 'background-color: white'};
                 border: 1px solid black;
                 padding: 3px;
+                ${options.styles}
             `;
 
 
@@ -1377,7 +1616,8 @@
                         tab.contents,
                         {
                             active: tab.default,
-                            padding: options.tabContent.padding
+                            padding: options.tabContent.padding,
+                            level: options.tabContent.level
                         }
                     )
                 );
@@ -1428,7 +1668,7 @@
             tab.className = classSelector;
             tab.style.cssText += `
                 padding: ${options.padding};
-                max-height: 70vh;
+                max-height: ${70 - (options.level || 0) * 5}vh;
                 overflow-y: auto;
                 display: ${options?.active ? 'block' : 'none'};
             `;

--- a/fuse.user.js
+++ b/fuse.user.js
@@ -1188,24 +1188,7 @@
             button.addEventListener('click', onClick);
 
             return button;
-        }
-
-        function makeTabElement(id, classSelector, content, options) {
-            const tab = document.createElement('div');
-            tab.id = id;
-            tab.className = classSelector;
-            tab.style.cssText += `
-                padding: 10px;
-                max-height: 70vh;
-                overflow-y: auto;
-                display: ${options?.active ? 'block' : 'none'};
-            `;
-
-
-            tab.appendChild(content);
-
-            return tab;
-        }
+        }   
 
         function makeLabelElement(text) {
             const label = document.createElement('label');
@@ -1376,6 +1359,22 @@
                 let tabContent = document.getElementById(`${contentSelector}_content`);
                 tabContent.style.display = 'block';
             }
+        }
+
+        function makeTabElement(id, classSelector, content, options) {
+            const tab = document.createElement('div');
+            tab.id = id;
+            tab.className = classSelector;
+            tab.style.cssText += `
+                padding: 10px;
+                max-height: 70vh;
+                overflow-y: auto;
+                display: ${options?.active ? 'block' : 'none'};
+            `;
+
+            tab.appendChild(content);
+
+            return tab;
         }
     }
 }

--- a/fuse.user.js
+++ b/fuse.user.js
@@ -22,6 +22,7 @@
     const UTILS = makeUtilsModule();
 
     const FUSE = makeFUSEConfiguratorModule();
+    const DATASOURCESTAB = makeDataSourcesTabModule()
     const BORISCHEN = makeBorisChenModule();
     const SUBVERTADOWN = makeSubvertADownModule();
     const CUSTOMDATA = makeCustomDataModule();
@@ -348,6 +349,37 @@
             return dynamicTeamNames;
         }
     }
+
+    function makeDataSourcesTabModule(){
+        const self = {
+            makeDataSourcesTabContent
+        }
+
+        return self;
+
+        function makeDataSourcesTabContent(){
+            const state = STORE.getState().data
+            let tabContent = document.createElement('div');
+
+            const borisChenTab = BORISCHEN.dataSourcesTab.createTabContent(state.borisChen)
+            const subvertADownTab = SUBVERTADOWN.dataSourcesTab.createTabContent(state.subvertADown);
+            const customDataTab = CUSTOMDATA.dataSourcesTab.createTabContent(state.customData);
+
+            tabContent.appendChild(DOM.makeTabs([
+                { label: 'BorisChen', default: true, contents: borisChenTab },
+                { label: 'SubvertADown', contents: subvertADownTab },
+                { label: 'CustomData', contents: customDataTab }
+            ], {
+                selector: FUSE.selectors.tabs.id,
+                tabLabels: {
+                    backgroundColor: '#eee',
+                    activeBackgroundColor: 'rgb(249, 249, 249',
+                }
+            }));
+
+            return tabContent
+        }
+    }
     function makeFUSEConfiguratorModule() {
         const self = {
             openConfigurator,
@@ -367,26 +399,8 @@
                 return;
             }
 
-            const state = STORE.getState().data
-
             let configModal = createConfiguratorModal();
-            let contentContainer = document.createElement('div');
-
-            const borisChenTab = BORISCHEN.dataSourcesTab.createTabContent(state.borisChen)
-            const subvertADownTab = SUBVERTADOWN.dataSourcesTab.createTabContent(state.subvertADown);
-            const customDataTab = CUSTOMDATA.dataSourcesTab.createTabContent(state.customData);
-
-            contentContainer.appendChild(DOM.makeTabs([
-                { label: 'BorisChen', default: true, contents: borisChenTab },
-                { label: 'SubvertADown', contents: subvertADownTab },
-                { label: 'CustomData', contents: customDataTab }
-            ], {
-                selector: self.selectors.tabs.id,
-                tabLabels: {
-                    backgroundColor: '#eee',
-                    activeBackgroundColor: 'rgb(249, 249, 249',
-                }
-            }));
+            const dataSourcesTab = DATASOURCESTAB.makeDataSourcesTabContent();
 
             let actionsSection = document.createElement('div');
             actionsSection.style.cssText = `
@@ -408,7 +422,7 @@
 
             actionsSection.appendChild(saveBtn);
             actionsSection.appendChild(DOM.makeButton('Hide', closeConfigurator));
-            configModal.appendChild(contentContainer);
+            configModal.appendChild(dataSourcesTab);
             configModal.appendChild(actionsSection);
             configModal.appendChild(createInfoSection());
 

--- a/fuse.user.js
+++ b/fuse.user.js
@@ -350,14 +350,20 @@
         }
     }
 
-    function makeDataSourcesTabModule(){
+    function makeDataSourcesTabModule() {
+        function dataSourcesTabSelector() {
+            return UI.makeSelector(`${FUSE.selectors.tabs.id}__dataSources`);
+        }
         const self = {
-            makeDataSourcesTabContent
+            makeDataSourcesTabContent,
+            selectors: {
+                root: dataSourcesTabSelector()
+            }
         }
 
         return self;
 
-        function makeDataSourcesTabContent(){
+        function makeDataSourcesTabContent() {
             const state = STORE.getState().data
             let tabContent = document.createElement('div');
 
@@ -370,10 +376,15 @@
                 { label: 'SubvertADown', contents: subvertADownTab },
                 { label: 'CustomData', contents: customDataTab }
             ], {
-                selector: FUSE.selectors.tabs.id,
+                selector: self.selectors.root.id,
                 tabLabels: {
                     backgroundColor: '#eee',
                     activeBackgroundColor: 'rgb(249, 249, 249',
+                    beforeContent: true,
+                    padding: '10px',
+                },
+                tabContent: {
+                    padding: '10px',
                 }
             }));
 
@@ -401,29 +412,25 @@
 
             let configModal = createConfiguratorModal();
             const dataSourcesTab = DATASOURCESTAB.makeDataSourcesTabContent();
+            let settingsTab = document.createElement('div');
+            settingsTab.innerText = 'Settings content'
+            configModal.appendChild(DOM.makeTabs([
+                { label: 'Data', default: true, contents: dataSourcesTab },
+                { label: 'Settings', contents: settingsTab },
+            ], {
+                selector: FUSE.selectors.tabs.id,
+                tabLabels: {
+                    backgroundColor: '#eee',
+                    activeBackgroundColor: 'rgb(249, 249, 249',
+                    padding: '5px',
+                    beforeContent: true,
+                },
+                tabContent: {
+                    padding: '0'
+                }
+            }));
 
-            let actionsSection = document.createElement('div');
-            actionsSection.style.cssText = `
-                padding: 10px;
-                border-top: 1px solid #ccc;
-            `;
-
-            const saveBtn = DOM.makeButton('Save', () => {
-                let state = STORE.getState();
-
-                state.data.borisChen = BORISCHEN.updateState(state.data.borisChen)
-                state.data.subvertADown = SUBVERTADOWN.updateState(state.data.subvertADown)
-                state.data.customData = CUSTOMDATA.updateState(state.data.customData)
-
-                STORE.saveState(state);
-                closeConfigurator();
-                UI.injectFUSEInfoIntoFantasySite();
-            });
-
-            actionsSection.appendChild(saveBtn);
-            actionsSection.appendChild(DOM.makeButton('Hide', closeConfigurator));
-            configModal.appendChild(dataSourcesTab);
-            configModal.appendChild(actionsSection);
+            configModal.appendChild(createActionsSection());
             configModal.appendChild(createInfoSection());
 
             document.body.insertBefore(configModal, document.getElementById(showConfiguratorBtn.id).nextSibling);
@@ -463,6 +470,31 @@
                 return dataSourcesTab
             }
 
+            function createActionsSection() {
+                let actionsSection = document.createElement('div');
+                actionsSection.style.cssText = `
+                    padding: 10px;
+                    border-top: 1px solid #ccc;
+                `;
+
+                const saveBtn = DOM.makeButton('Save', () => {
+                    let state = STORE.getState();
+
+                    state.data.borisChen = BORISCHEN.updateState(state.data.borisChen)
+                    state.data.subvertADown = SUBVERTADOWN.updateState(state.data.subvertADown)
+                    state.data.customData = CUSTOMDATA.updateState(state.data.customData)
+
+                    STORE.saveState(state);
+                    closeConfigurator();
+                    UI.injectFUSEInfoIntoFantasySite();
+                });
+
+                actionsSection.appendChild(saveBtn);
+                actionsSection.appendChild(DOM.makeButton('Hide', closeConfigurator));
+
+                return actionsSection;
+            }
+
         }
 
         function closeConfigurator() {
@@ -471,8 +503,10 @@
     }
 
     function makeBorisChenModule() {
+        const rootSelector = `${DATASOURCESTAB.selectors.root.id}__borisChen`;
+
         function borisChenSelector(id, attribute) {
-            return UI.makeSelector(`${FUSE.selectors.tabs.id}__borisChen_${id}`, attribute);
+            return UI.makeSelector(`${rootSelector}_${id}`, attribute);
         }
 
         const scoreSuffix = {
@@ -496,8 +530,8 @@
                     lastFetched: borisChenSelector('lastFetched', 'data-state'),
                     fetchDataBtn: borisChenSelector('fetchDataBtn'),
                     positions: {
-                        id: (position) => `${FUSE.selectors.tabs.id}_borisChen_${position}`,
-                        get: (position) => document.getElementById(`${FUSE.selectors.tabs.id}_borisChen_${position}`),
+                        id: (position) => `${rootSelector}_${position}`,
+                        get: (position) => document.getElementById(`${rootSelector}_${position}`),
                         getValue: function (position) {
                             const el = this.get(position);
                             return el ? el.value : '';
@@ -790,8 +824,9 @@
     }
 
     function makeSubvertADownModule() {
+        const rootSelector = `${DATASOURCESTAB.selectors.root.id}__subvertADown`;
         function subvertADownSelector(id, attribute) {
-            return UI.makeSelector(`${FUSE.selectors.tabs.id}__subvertADown_${id}`, attribute);
+            return UI.makeSelector(`${rootSelector}_${id}`, attribute);
         }
 
         const self = {
@@ -805,9 +840,8 @@
                     prefix: subvertADownSelector('prefix'),
                     raw: subvertADownSelector('raw'),
                     positions: {
-                        // TODO_JB these tab selectors will need to be more specific
-                        id: (position) => `${FUSE.selectors.tabs.id}_subvertADown_${position}`,
-                        get: (position) => document.getElementById(`${FUSE.selectors.tabs.id}_subvertADown_${position}`),
+                        id: (position) => `${rootSelector}_${position}`,
+                        get: (position) => document.getElementById(`${rootSelector}_${position}`),
                         getValue: function (position) {
                             const el = this.get(position);
                             return el ? el.value : '';
@@ -931,8 +965,9 @@
     }
 
     function makeCustomDataModule() {
+        const rootSelector = `${DATASOURCESTAB.selectors.root.id}__customData`;
         function customDataSelector(id, attribute) {
-            return UI.makeSelector(`${FUSE.selectors.tabs.id}__customData_${id}`, attribute);
+            return UI.makeSelector(`${rootSelector}_${id}`, attribute);
         }
 
         const self = {
@@ -1203,7 +1238,7 @@
             button.addEventListener('click', onClick);
 
             return button;
-        }   
+        }
 
         function makeLabelElement(text) {
             const label = document.createElement('label');
@@ -1317,7 +1352,7 @@
                 tabNameLabel.classList.add(`${options.selector}_label`);
 
                 tabNameLabel.style.cssText = `
-                    padding: 10px;
+                    padding: ${options.tabLabels.padding};
                     width: 100%;
                     cursor: pointer;
                     border-bottom: 1px solid #ccc;
@@ -1340,13 +1375,24 @@
                         `${options.selector}_${index}_content`,
                         `${options.selector}_content`,
                         tab.contents,
-                        { active: tab.default }
+                        {
+                            active: tab.default,
+                            padding: options.tabContent.padding
+                        }
                     )
                 );
+
             });
 
-            tabContainer.appendChild(tabLabels);
+            if (options.tabLabels.beforeContent) {
+                tabContainer.appendChild(tabLabels);
+            }
+
             tabContainer.appendChild(tabContents);
+
+            if (options.tabLabels.afterContent) {
+                tabContainer.appendChild(tabLabels);
+            }
 
             return tabContainer;
 
@@ -1381,7 +1427,7 @@
             tab.id = id;
             tab.className = classSelector;
             tab.style.cssText += `
-                padding: 10px;
+                padding: ${options.padding};
                 max-height: 70vh;
                 overflow-y: auto;
                 display: ${options?.active ? 'block' : 'none'};

--- a/fuse.user.js
+++ b/fuse.user.js
@@ -354,8 +354,7 @@
             hideSettings,
             selectors: {
                 panel: UI.makeSelector('fuseSettingsPanel'),
-                tabLabels: UI.makeSelector('fuseSettingsPanel__tabLabel'),
-                tabContents: UI.makeSelector('fuseSettingsPanel__tabContent'),
+                tabs: UI.makeSelector('fuseSettingsPanel__tabs'),
             }
         }
 
@@ -371,28 +370,23 @@
             const state = STORE.getState().data
 
             let settingsPanel = createMainSettingsPanel();
-            let contentContainer = document.createElement('div');            
+            let contentContainer = document.createElement('div');
 
             const borisChenTab = BORISCHEN.settingsPanel.createTab(state.borisChen)
             const subvertADownTab = SUBVERTADOWN.settingsPanel.createSubvertADownTab(state.subvertADown);
             const customDataTab = CUSTOMDATA.settingsPanel.createCustomDataTab(state.customData);
 
             contentContainer.appendChild(DOM.makeTabs([
-                { contentSelector: borisChenTab.id, label: 'BorisChen', default: true },
-                { contentSelector: subvertADownTab.id, label: 'SubvertADown' },
-                { contentSelector: customDataTab.id, label: 'CustomData' }
+                { label: 'BorisChen', default: true, contents: borisChenTab },
+                { label: 'SubvertADown', contents: subvertADownTab },
+                { label: 'CustomData', contents: customDataTab }
             ], {
-                tabLabelsSelector: self.selectors.tabLabels.id,
-                tabContentsSelector: self.selectors.tabContents.id,
+                selector: self.selectors.tabs.id,
                 tabLabels: {
                     backgroundColor: '#eee',
                     activeBackgroundColor: 'rgb(249, 249, 249',
                 }
             }));
-
-            contentContainer.appendChild(borisChenTab);
-            contentContainer.appendChild(subvertADownTab);
-            contentContainer.appendChild(customDataTab);
 
             let actionsSection = document.createElement('div');
             actionsSection.style.cssText = `
@@ -419,7 +413,6 @@
             settingsPanel.appendChild(createInfoSection());
 
             document.body.insertBefore(settingsPanel, document.getElementById(showSettingsBtn.id).nextSibling);
-            activateTab(borisChenTab.id);
 
             function createInfoSection() {
                 const info = document.createElement('div');
@@ -465,7 +458,7 @@
 
     function makeBorisChenModule() {
         function borisChenSelector(id, attribute) {
-            return UI.makeSelector(`${SETTINGS.selectors.tabContents.id}__borisChen_${id}`, attribute);
+            return UI.makeSelector(`${SETTINGS.selectors.tabs.id}__borisChen_${id}`, attribute);
         }
 
         const scoreSuffix = {
@@ -489,8 +482,8 @@
                     lastFetched: borisChenSelector('lastFetched', 'data-state'),
                     fetchDataBtn: borisChenSelector('fetchDataBtn'),
                     positions: {
-                        id: (position) => `${SETTINGS.selectors.tabContents.id}_borisChen_${position}`,
-                        get: (position) => document.getElementById(`${SETTINGS.selectors.tabContents.id}_borisChen_${position}`),
+                        id: (position) => `${SETTINGS.selectors.tabs.id}_borisChen_${position}`,
+                        get: (position) => document.getElementById(`${SETTINGS.selectors.tabs.id}_borisChen_${position}`),
                         getValue: function (position) {
                             const el = this.get(position);
                             return el ? el.value : '';
@@ -674,13 +667,11 @@
 
         function createTab(savedData) {
             const { selectors } = self.settingsPanel;
-            const tab = DOM.makeTabElement(
-                selectors.tab.id,
-                "Configure your league scoring setting and automatically fetch data from from www.borisChen.co or paste it in manually.",
-                {
-                    active: true
-                }
-            );
+            const tabContent = document.createElement('div');
+            const helpText = document.createElement('p');
+            helpText.textContent = 'Configure your league scoring setting and automatically fetch data from from www.borisChen.co or paste it in manually.';
+            helpText.style.marginBottom = '10px';
+            tabContent.appendChild(helpText);
 
             const prefixField = DOM.makeInputField(
                 'Prefix (optional)',
@@ -689,7 +680,7 @@
                 savedData.prefix,
             );
 
-            tab.appendChild(prefixField);
+            tabContent.appendChild(prefixField);
             const positions = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'DST', 'K'];
             if (GM?.info) {
                 const dataSettings = document.createElement('div');
@@ -747,8 +738,8 @@
                 dataSettings.appendChild(autoFetchField);
                 dataSettings.appendChild(lastFetchedField);
 
-                tab.appendChild(dataSettings);
-                tab.appendChild(fetchDataBtn);
+                tabContent.appendChild(dataSettings);
+                tabContent.appendChild(fetchDataBtn);
             }
 
             for (const position of positions) {
@@ -758,10 +749,10 @@
                     savedData.raw[position],
                 );
 
-                tab.appendChild(positionField);
+                tabContent.appendChild(positionField);
             }
 
-            return tab;
+            return tabContent;
         }
 
         function getFormData() {
@@ -786,7 +777,7 @@
 
     function makeSubvertADownModule() {
         function subvertADownSelector(id, attribute) {
-            return UI.makeSelector(`${SETTINGS.selectors.tabContents.id}__subvertADown_${id}`, attribute);
+            return UI.makeSelector(`${SETTINGS.selectors.tabs.id}__subvertADown_${id}`, attribute);
         }
 
         const self = {
@@ -800,8 +791,8 @@
                     prefix: subvertADownSelector('prefix'),
                     raw: subvertADownSelector('raw'),
                     positions: {
-                        id: (position) => `${SETTINGS.selectors.tabContents.id}_subvertADown_${position}`,
-                        get: (position) => document.getElementById(`${SETTINGS.selectors.tabContents.id}_subvertADown_${position}`),
+                        id: (position) => `${SETTINGS.selectors.tabs.id}_subvertADown_${position}`,
+                        get: (position) => document.getElementById(`${SETTINGS.selectors.tabs.id}_subvertADown_${position}`),
                         getValue: function (position) {
                             const el = this.get(position);
                             return el ? el.value : '';
@@ -839,10 +830,12 @@
             return `${state.prefix || ''}${playerInfo}`
         }
         function createSubvertADownTab(savedData) {
-            const tab = DOM.makeTabElement(
-                self.settingsPanel.selectors.tab.id,
-                "Copy data from https://subvertadown.com and paste the raw tier info into the below text areas."
-            );
+            const tabContent = document.createElement('div');
+
+            const helpText = document.createElement('p');
+            helpText.textContent = 'Copy data from https://subvertadown.com and paste the raw tier info into the below text areas.';
+            helpText.style.marginBottom = '10px';
+            tabContent.appendChild(helpText);
 
             const prefixField = DOM.makeInputField(
                 'Prefix (optional)',
@@ -851,7 +844,7 @@
                 savedData.prefix,
             );
 
-            tab.appendChild(prefixField);
+            tabContent.appendChild(prefixField);
 
             const positions = ['DST', 'QB', 'K'];
 
@@ -862,10 +855,10 @@
                     savedData.raw[position],
                 );
 
-                tab.appendChild(positionField);
+                tabContent.appendChild(positionField);
             }
 
-            return tab;
+            return tabContent;
         }
 
         function getSubvertADownFormData() {
@@ -924,7 +917,7 @@
 
     function makeCustomDataModule() {
         function customDataSelector(id, attribute) {
-            return UI.makeSelector(`${SETTINGS.selectors.tabContents.id}__customData_${id}`, attribute);
+            return UI.makeSelector(`${SETTINGS.selectors.tabs.id}__customData_${id}`, attribute);
         }
 
         const self = {
@@ -977,10 +970,12 @@
 
         function createCustomDataTab(savedData) {
             const { selectors } = self.settingsPanel;
-            const tab = DOM.makeTabElement(
-                selectors.tab.id,
-                "Paste in your own data from a spreadsheet or another website."
-            );
+            const tabContent = document.createElement('div');
+
+            const helpText = document.createElement('p');
+            helpText.textContent = 'Paste in your own data from a spreadsheet or another website.';
+            helpText.style.marginBottom = '10px';
+            tabContent.appendChild(helpText);
 
             const prefixField = DOM.makeInputField(
                 'Prefix (optional)',
@@ -989,7 +984,7 @@
                 savedData.prefix,
             );
 
-            tab.appendChild(prefixField);
+            tabContent.appendChild(prefixField);
             const dataSettings = document.createElement('div');
             dataSettings.style.cssText = `
                 display: flex;
@@ -1021,7 +1016,7 @@
             );
             dataSettings.appendChild(displayColumnField);
 
-            tab.appendChild(dataSettings);
+            tabContent.appendChild(dataSettings);
 
             const positionField = DOM.makeTextAreaField(
                 'Custom',
@@ -1030,9 +1025,9 @@
                 { height: '200px', placeholder: 'Patrick Mahomes, Regress to mean' }
             );
 
-            tab.appendChild(positionField);
+            tabContent.appendChild(positionField);
 
-            return tab;
+            return tabContent;
         }
 
         function getCustomDataFormData() {
@@ -1195,10 +1190,10 @@
             return button;
         }
 
-        function makeTabElement(id, content, options) {
+        function makeTabElement(id, classSelector, content, options) {
             const tab = document.createElement('div');
             tab.id = id;
-            tab.className = SETTINGS.selectors.tabContents.id;
+            tab.className = classSelector;
             tab.style.cssText += `
                 padding: 10px;
                 max-height: 70vh;
@@ -1206,11 +1201,8 @@
                 display: ${options?.active ? 'block' : 'none'};
             `;
 
-            const helpText = document.createElement('p');
-            helpText.textContent = content;
-            helpText.style.marginBottom = '10px';
 
-            tab.appendChild(helpText);
+            tab.appendChild(content);
 
             return tab;
         }
@@ -1310,18 +1302,21 @@
         }
 
         function makeTabs(tabs, options) {
-            const tabsContainer = document.createElement('div');
-            tabsContainer.style.cssText = `
+            const tabContainer = document.createElement('div');
+            const tabLabels = document.createElement('div');
+            tabLabels.style.cssText = `
                 display: flex;  
                 justify-content: space-between;
                 background-color: ${options.tabLabels.backgroundColor};  
             `;
 
-            tabs.forEach(tab => {
+            const tabContents = document.createElement('div');
+
+            tabs.forEach((tab, index) => {
                 const tabNameLabel = document.createElement('div');
                 tabNameLabel.textContent = tab.label;
-                tabNameLabel.id = `${tab.contentSelector}_label`;
-                tabNameLabel.classList.add(options.tabLabelsSelector);
+                tabNameLabel.id = `${options.selector}_${index}_label`;
+                tabNameLabel.classList.add(`${options.selector}_label`);
 
                 tabNameLabel.style.cssText = `
                     padding: 10px;
@@ -1331,31 +1326,42 @@
                     background-color: inherit;
                 `;
 
-                if(tab.default){
+                if (tab.default) {
                     tabNameLabel.style.borderBottom = 'none';
                     tabNameLabel.style.backgroundColor = options.tabLabels.activeBackgroundColor;
                 }
 
                 tabNameLabel.addEventListener('click', () => {
                     hideAllTabs();
-                    showTab(tab.contentSelector);
+                    showTab(`${options.selector}_${index}`);
                 });
 
-                tabsContainer.appendChild(tabNameLabel);
+                tabLabels.appendChild(tabNameLabel);
+                tabContents.appendChild(
+                    makeTabElement(
+                        `${options.selector}_${index}_content`,
+                        `${options.selector}_content`,
+                        tab.contents,
+                        { active: tab.default }
+                    )
+                );
             });
 
-            return tabsContainer;
+            tabContainer.appendChild(tabLabels);
+            tabContainer.appendChild(tabContents);
+
+            return tabContainer;
 
 
             function hideAllTabs() {
-                const tabLabel = document.querySelectorAll(`.${options.tabLabelsSelector}`);
+                const tabLabel = document.querySelectorAll(`.${options.selector}_label`);
 
                 tabLabel.forEach(tab => {
                     tab.style.borderBottom = '1px solid #ccc';
                     tab.style.backgroundColor = 'inherit';
                 });
 
-                const tabContents = document.querySelectorAll(`.${options.tabContentsSelector}`);
+                const tabContents = document.querySelectorAll(`.${options.selector}_content`);
 
                 tabContents.forEach(tab => {
                     tab.style.display = 'none';
@@ -1367,7 +1373,7 @@
                 tabNameLabel.style.borderBottom = 'none';
                 tabNameLabel.style.backgroundColor = options.tabLabels.activeBackgroundColor;
 
-                let tabContent = document.getElementById(`${contentSelector}`);
+                let tabContent = document.getElementById(`${contentSelector}_content`);
                 tabContent.style.display = 'block';
             }
         }


### PR DESCRIPTION
- Added new tabbed UI
- Grouped existing boris chen, subvertadown, and custom data tabs under the Data Sources tab
- Added a new Settings tab which contains various ways to configure FUSE
  - general settings to configure delimiters (between data sources and multiple stats for one player) 
  - platform selectors: Exposes the DOM selectors FUSE uses to inject data. This allows for extended longevity for FUSE when fantasy platforms update their DOM.

![image](https://github.com/jarekb84/FUSE/assets/667983/32931490-ed52-4a06-ad4c-6d444682c005)

![image](https://github.com/jarekb84/FUSE/assets/667983/971bfa4b-7887-4d2e-a82e-25c443a63538)
![image](https://github.com/jarekb84/FUSE/assets/667983/d368e1e3-8b16-4020-af5d-eb530ef2b109)

